### PR TITLE
Remove blog link from footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,7 +28,6 @@ const Footer: React.FC = () => {
             <ul className="footer-links">
               <li><a href="https://github.com" target="_blank" rel="noopener noreferrer">GitHub</a></li>
               <li><a href="https://discord.gg/acfgTbdErv" target="_blank" rel="noopener noreferrer">Discord</a></li>
-              <li><a href="#blog">Blog</a></li>
             </ul>
           </div>
           


### PR DESCRIPTION
## Summary
- remove Blog link from community section in footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bfd0552920832bbbdf740a4727ed55