### PR TITLE
Fix hero animation cropping on mobile

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,7 +1,9 @@
 .hero-section {
   position: relative;
   width: 100vw;
+  /* Use dynamic viewport height so the hero fills the screen on mobile */
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   display: flex;
   align-items: center;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -13,8 +13,10 @@ const HeroSection: React.FC = () => {
     if (!ctx) return;
 
     const resizeCanvas = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
+      const width = window.innerWidth;
+      const height = window.visualViewport?.height ?? window.innerHeight;
+      canvas.width = width;
+      canvas.height = height;
     };
 
     resizeCanvas();


### PR DESCRIPTION
## Summary
- Use dynamic viewport units for hero section height to prevent mobile cropping
- Resize hero animation canvas using `visualViewport` for accurate screen dimensions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd197fd58832ba2c99e4957bf5b75