### PR TITLE
Fix hero content cropping on mobile

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,7 +1,9 @@
 .hero-section {
   position: relative;
   width: 100vw;
-  height: 100vh;
+  /* Ensure the hero is at least full-screen but can expand if content overflows */
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   display: flex;
   align-items: center;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -13,8 +13,11 @@ const HeroSection: React.FC = () => {
     if (!ctx) return;
 
     const resizeCanvas = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
+      const parent = canvas.parentElement as HTMLElement | null;
+      const width = parent?.clientWidth ?? window.innerWidth;
+      const height = parent?.clientHeight ?? window.innerHeight;
+      canvas.width = width;
+      canvas.height = height;
     };
 
     resizeCanvas();


### PR DESCRIPTION
## Summary
- Allow hero section to expand beyond the viewport so text and stat boxes aren't clipped on small screens
- Resize hero animation canvas based on the hero's actual dimensions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd197fd58832ba2c99e4957bf5b75