### PR TITLE
Fix hero content cropping on mobile

### DIFF
--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,7 +1,9 @@
 .hero-section {
   position: relative;
   width: 100vw;
-  height: 100vh;
+  /* Ensure the hero is at least full-screen but can expand if content overflows */
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -22,7 +24,7 @@
   z-index: 10;
   text-align: center;
   max-width: 1200px;
-  padding: 0 2rem;
+  padding: 6rem 2rem 5rem;
   animation: fadeInUp 1s ease-out;
 }
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,6 +4,7 @@ import './HeroSection.css';
 const HeroSection: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number | undefined>(undefined);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -13,12 +14,26 @@ const HeroSection: React.FC = () => {
     if (!ctx) return;
 
     const resizeCanvas = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
+      const parent = canvas.parentElement as HTMLElement | null;
+      const width = parent?.clientWidth ?? window.innerWidth;
+      const height = parent?.clientHeight ?? window.innerHeight;
+      canvas.width = width;
+      canvas.height = height;
     };
 
-    resizeCanvas();
-    window.addEventListener('resize', resizeCanvas);
+    const updateLayout = () => {
+      resizeCanvas();
+      const header = document.querySelector('.header') as HTMLElement | null;
+      const heroContent = contentRef.current;
+      if (heroContent) {
+        const headerHeight = header?.offsetHeight ?? 0;
+        heroContent.style.paddingTop = `${headerHeight + 32}px`;
+        heroContent.style.paddingBottom = '80px';
+      }
+    };
+
+    updateLayout();
+    window.addEventListener('resize', updateLayout);
 
     class Node {
       x: number;
@@ -260,7 +275,7 @@ const HeroSection: React.FC = () => {
     animate();
 
     return () => {
-      window.removeEventListener('resize', resizeCanvas);
+      window.removeEventListener('resize', updateLayout);
       if (animationRef.current) {
         cancelAnimationFrame(animationRef.current);
       }
@@ -270,7 +285,7 @@ const HeroSection: React.FC = () => {
   return (
     <section className="hero-section">
       <canvas ref={canvasRef} className="hero-canvas" />
-      <div className="hero-content">
+      <div className="hero-content" ref={contentRef}>
         <h1 className="hero-title">
           <span className="hero-title-line">Composable Building Blocks</span>
           <span className="hero-title-line gradient">for FoundationDB</span>


### PR DESCRIPTION
## Summary
- Offset hero content based on header height so tagline isn't hidden
- Add breathing room after hero stats and recalc layout on resize

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd197fd58832ba2c99e4957bf5b75